### PR TITLE
Fix bug with last move

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -126,7 +126,6 @@ class Game:
         if player['token'] != token:
             raise ForbiddenMoveError
         try:
-            self._game.move(move)
 
             if self._last_move and self._last_move['player'] == self._whose_turn():
                 self._last_move['last_moves'].append(move)
@@ -135,6 +134,7 @@ class Game:
                     'player': self._whose_turn(),
                     'last_moves': [move]
                 }
+            self._game.move(move)
 
             self._available_current_move_time = self._available_move_time
         except ValueError as e:


### PR DESCRIPTION
Previously move was registered before `self._last_move` was updated and so `self._whose_turn()` changes color before needed. For example on 1st turn of the game `self._last_move` would be something like this
```
{
  'player': 'BLACK',
  'last_moves': [x y]
}
```
however `player` must be `RED` in this case.
This small PR fixes this behavior.